### PR TITLE
Add arm64 to Dockerfile.run

### DIFF
--- a/Dockerfile.run
+++ b/Dockerfile.run
@@ -2,3 +2,6 @@ gokalpgoren
     amd64:
             docker build -t gokalpgoren/snapshot_service:v1.0.3-amd64 .
             docker run -it --restart unless-stopped --name snapshot_service-instance --net host -e TZ=Europe/Istanbul gokalpgoren/snapshot_service:v1.0.3-amd64
+
+    arm64:
+            docker build -t gokalpgoren/snapshot_service:v1.0.3-arm64v8 .


### PR DESCRIPTION
It looks like a tradition to have the arm64 command listed separately and I'm preparing a script to build the arm containers based on the contents in Dockerfile.run